### PR TITLE
Fix 'BitmapEditorPanel' Bugs

### DIFF
--- a/ABSpriteEditor/ABSpriteEditor/Controls/BitmapEditorPanel.cs
+++ b/ABSpriteEditor/ABSpriteEditor/Controls/BitmapEditorPanel.cs
@@ -186,8 +186,11 @@ namespace ABSpriteEditor.Controls
             var xScale = (this.Width / this.Image.Width);
             var yScale = (this.Height / this.Image.Height);
 
-            // Set the image scale to the least of the two scales
-            this.ImageScale = Math.Min(xScale, yScale);
+            // Select the least of the two scales
+            var smallerScale = Math.Min(xScale, yScale);
+
+            // Set the image scale, ensuring it is not less than 1
+            this.ImageScale = Math.Max(smallerScale, 1);
         }
 
         // Set the scale back to its minimum

--- a/ABSpriteEditor/ABSpriteEditor/Controls/BitmapEditorPanel.cs
+++ b/ABSpriteEditor/ABSpriteEditor/Controls/BitmapEditorPanel.cs
@@ -181,9 +181,12 @@ namespace ABSpriteEditor.Controls
         // whilst still fitting the image within the editor panel
         public void MaximiseScale()
         {
+            // Derive the potential scale from the ratio between
+            // the control's dimensions and the image's dimensions
             var xScale = (this.Width / this.Image.Width);
             var yScale = (this.Height / this.Image.Height);
 
+            // Set the image scale to the least of the two scales
             this.ImageScale = Math.Min(xScale, yScale);
         }
 

--- a/ABSpriteEditor/ABSpriteEditor/Controls/BitmapEditorPanel.cs
+++ b/ABSpriteEditor/ABSpriteEditor/Controls/BitmapEditorPanel.cs
@@ -165,6 +165,11 @@ namespace ABSpriteEditor.Controls
 
         public void CentreOffset()
         {
+            // If there is no image
+            if (this.Image == null)
+                // Exit early
+                return;
+
             // Calculate the scaled size of the image
             var width = (this.Image.Width * this.ImageScale);
             var height = (this.Image.Height * this.ImageScale);
@@ -181,6 +186,11 @@ namespace ABSpriteEditor.Controls
         // whilst still fitting the image within the editor panel
         public void MaximiseScale()
         {
+            // If there is no image
+            if (this.Image == null)
+                // Exit early
+                return;
+
             // Derive the potential scale from the ratio between
             // the control's dimensions and the image's dimensions
             var xScale = (this.Width / this.Image.Width);


### PR DESCRIPTION
This change fixes a bug that occurs when the editor uses an image that is bigger than the edit panel itself, as well as preventing potential null reference exceptions in `MaximiseScale` and `CentreOffset`.