### PR TITLE
Fix Transparent Pixel Encoding

### DIFF
--- a/ABSpriteEditor/ABSpriteEditor/Sprites/IO/SpriteEncoding.cs
+++ b/ABSpriteEditor/ABSpriteEditor/Sprites/IO/SpriteEncoding.cs
@@ -92,7 +92,7 @@ namespace ABSpriteEditor.Sprites.IO
                         var pixel = bitmap.GetPixel(column, y);
                         var average = Average(pixel);
 
-                        if (average > 127)
+                        if ((pixel.A == 0xFF) && (average > 127))
                             imageByte |= (byte)(1 << bitIndex);
 
                         if (pixel.A == 0xFF)


### PR DESCRIPTION
The code was treating transparent pixels as if the mask channel were an alpha channel, but unfortunately the Arduboy2 Sprites format requires that both a mask bit and its corresponding image bit must be zero for the pixel to be truly transparent. This change fixes the issue by ensuring that if a source pixel is transparent the image data isn't encoded, leaving the destination bit as zero.

Thanks to @ace-dent for bringing this issue to my attention.