### PR TITLE
Add Larger 'Zoom In' and 'Zoom Out' Icons

### DIFF
--- a/ABSpriteEditor/ABSpriteEditor/Properties/Resources.Designer.cs
+++ b/ABSpriteEditor/ABSpriteEditor/Properties/Resources.Designer.cs
@@ -793,9 +793,29 @@ namespace ABSpriteEditor.Properties {
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
+        internal static System.Drawing.Bitmap ZoomIn32 {
+            get {
+                object obj = ResourceManager.GetObject("ZoomIn32", resourceCulture);
+                return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Bitmap.
+        /// </summary>
         internal static System.Drawing.Bitmap ZoomOut16 {
             get {
                 object obj = ResourceManager.GetObject("ZoomOut16", resourceCulture);
+                return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Bitmap.
+        /// </summary>
+        internal static System.Drawing.Bitmap ZoomOut32 {
+            get {
+                object obj = ResourceManager.GetObject("ZoomOut32", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }

--- a/ABSpriteEditor/ABSpriteEditor/Properties/Resources.resx
+++ b/ABSpriteEditor/ABSpriteEditor/Properties/Resources.resx
@@ -340,4 +340,10 @@
   <data name="RenameIcon32" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\UI\SpriteEditor\TreeView\RenameIcon32.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
+  <data name="ZoomIn32" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\UI\SpriteEditor\TreeView\ZoomIn32.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ZoomOut32" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\UI\SpriteEditor\TreeView\ZoomOut32.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
 </root>


### PR DESCRIPTION
These aren't used (yet), but I'm registering them as resources for consistency.
I should have done this before trying to add the rename feature really, it would have made the commit history a bit cleaner.